### PR TITLE
Use PPM R package binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ name: Quarto Publish
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install R packages
         run: |
-          Rscript -e 'install.packages(c("shiny", "dplyr", "bslib", "bsicons", "shinylive", "rmarkdown", "knitr", "jsonlite"))'
+          Rscript -e 'install.packages(c("shiny", "dplyr", "bslib", "bsicons", "shinylive", "rmarkdown", "knitr", "jsonlite"), repos = sprintf("https://packagemanager.posit.co/cran/2025-10-08/bin/linux/noble-%s/%s", R.version["arch"], substr(getRversion(), 1, 3)))'
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
Using Posit Package Manager binaries to speed up GH Actions package installation step.

Closes #9 