### PR TITLE
feat: add RSS feed for hangout recordings posts

### DIFF
--- a/docs/hangout/recordings/index.qmd
+++ b/docs/hangout/recordings/index.qmd
@@ -9,7 +9,8 @@ listing:
   filter-ui: false
   fields: [title, subtitle, author, date, image]
   image-align: left
-  page-size: 5
+  page-size: 10
+  feed: true
 comments: false
 
 format:

--- a/docs/hangout/upcoming/index.qmd
+++ b/docs/hangout/upcoming/index.qmd
@@ -36,7 +36,7 @@ hangouts:
 ---
 
 Each month R/Pharma brings you a live Hangout featuring key innovators across the world of open source and life sciences.  
-Join us for upcoming R/Pharma Hangouts, and check out our [recordings](/docs/hangout/recordings) to catch up on past events.
+Join us for upcoming R/Pharma Hangouts, and check out our [recordings](/docs/hangout/recordings) to catch up on past events. Use the recordings [RSS feed](../recordings/index.xml) in your favorite RSS application to be notified when recordings are available.
 
 Keep up to date with [LinkedIn events and announcements](https://www.linkedin.com/company/open-source-in-pharma/) for each Hangout and, if you have a topic or guest you'd like to see featured, please reach out to us at [info@rinpharma.com](mailto:info@rinpharma.com) or via our [contact form](/contact.qmd).
 


### PR DESCRIPTION
A [feature request](https://fosstodon.org/@jonocarroll/116600058368451133) came my way from Jonathan Carroll to produce an RSS feed for our Hangouts recordings on the site. Thanks to Quarto, this was an easy feature to implement!